### PR TITLE
Fix: 로그인 에러 문구 수정

### DIFF
--- a/smartglot-react/src/contexts/AuthContext.jsx
+++ b/smartglot-react/src/contexts/AuthContext.jsx
@@ -43,12 +43,22 @@ export function AuthProvider({ children }) {
         email,
         password,
       );
-      // onAuthStateChanged가 currentUser를 업데이트하고 emailVerified를 확인할 것임
       return userCredential.user;
     } catch (e) {
-      console.error('Login failed:', e);
-      setError(e.message);
-      throw e;
+      console.error('Login failed in AuthContext:', e);
+      if (e.code === 'auth/invalid-credential') {
+        // fetchSignInMethodsForEmail을 여기서 호출하지 않고,
+        // 일반적인 로그인 실패 메시지와 함께 Google 로그인 가능성을 안내합니다.
+        const specificMessage =
+          '이메일 또는 비밀번호가 잘못되었습니다. Google 계정으로 가입하셨다면 Google 로그인을 이용해 보세요.';
+        setError(specificMessage);
+        throw new Error(specificMessage); // AuthPage로 에러를 전달
+      } else {
+        // auth/invalid-credential 이외의 다른 Firebase 에러 코드들
+        // (예: auth/user-not-found, auth/wrong-password, auth/too-many-requests 등)
+        setError(e.message); // Firebase에서 제공하는 기본 에러 메시지 사용
+        throw e;
+      }
     }
   }
 


### PR DESCRIPTION
## 스크린샷

<img width="500" alt="스크린샷 2025-05-11 오후 8 56 50" src="https://github.com/user-attachments/assets/0d360316-03b8-44ed-aa3f-520100e3d50a" />

<img width="500" alt="스크린샷 2025-05-11 오후 9 19 49" src="https://github.com/user-attachments/assets/a822d3a3-bfc5-4bf5-bce3-ff24dd0e333e" />

## 변경사항
구글 로그인으로 가입한 사용자가 구글로그인이 아닌 이메일 로그인을 시도할 때  스크린샷과 같은 에러가 발생해 혼란이 있었음. 그래서 에러 문구를 변경함.